### PR TITLE
Search type in panel

### DIFF
--- a/src/Kdyby/ElasticSearch/Diagnostics/panel.phtml
+++ b/src/Kdyby/ElasticSearch/Diagnostics/panel.phtml
@@ -29,6 +29,11 @@
 				<td><?php echo $click($requestData, TRUE, 15); ?></td>
 			</tr><?php } ?>
 
+			<tr>
+				<th width="70">Search type:</th>
+				<td><?php echo isset($request->getQuery()[\Elastica\Search::OPTION_SEARCH_TYPE]) ? $esc($request->getQuery()[\Elastica\Search::OPTION_SEARCH_TYPE]) : 'search' ?></td>
+			</tr>
+
 			<?php if ($response && $response->isOk()) { $responseData = $extractData($response); ?>
 				<?php if (stripos($request->getPath(), '_search') !== FALSE) { ?>
 					<?php if (isset($responseData['took'])) { ?><tr>


### PR DESCRIPTION
There are different [search types](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-search-type.html) with different semantics. Some of them can be performed using a [dedicated API](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-count.html) however 1) Elastica doesn't support this (when calling `->count()`, it does not use the count API but the Search API using `search_type=count`), 2) using the `search_type` parameter is [the preferred way](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-search-type.html#count). However at the moment there is no way to see the search type used by a particular request. And we believe it is an important piece of information because different search types - while sometimes semantically interchangeable - have different implications ([`count` requests can be cached](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-shard-query-cache.html), etc.).

Therefore we suggest this humble pull request that adds a new row to the panel for every request with the appropriate `search_type` used. If there is no search type explicitly set, `search` will be displayed.
