### PR TITLE
Added tracy bar icon width property

### DIFF
--- a/src/Kdyby/ElasticSearch/Diagnostics/Panel.php
+++ b/src/Kdyby/ElasticSearch/Diagnostics/Panel.php
@@ -59,7 +59,7 @@ class Panel extends Nette\Object implements IBarPanel
 	 */
 	public function getTab()
 	{
-		$img = Html::el('img', array('height' => '16px'))
+		$img = Html::el('img', array('height' => '14', 'width' => '14'))
 			->src('data:image/png;base64,' . base64_encode(file_get_contents(__DIR__ . '/logo.png')));
 		$tab = Html::el('span')->title('ElasticSearch')->add($img);
 		$title = Html::el()->setText('ElasticSearch');


### PR DESCRIPTION
It look better with new panel (14px). Before:
![vystrizek](https://cloud.githubusercontent.com/assets/978368/7836298/79e7a3b8-047f-11e5-977d-657d193e8b4f.PNG)
After:
![vystrizek](https://cloud.githubusercontent.com/assets/978368/7836319/9fd68800-047f-11e5-90e7-238786c5bcb7.PNG)
(Google Chrome 43.0.2357.65 dev-m)
