### PR TITLE
replace callback() with Callback class, use escapeHtml from  Latte

### DIFF
--- a/src/Kdyby/ElasticSearch/Diagnostics/Panel.php
+++ b/src/Kdyby/ElasticSearch/Diagnostics/Panel.php
@@ -14,6 +14,7 @@ use Elastica\Exception\ExceptionInterface;
 use Elastica;
 use Kdyby;
 use Nette;
+use Nette\Utils\Callback;
 use Nette\Utils\Html;
 use Nette\Utils\Json;
 use Tracy\Debugger;
@@ -84,12 +85,14 @@ class Panel extends Nette\Object implements IBarPanel
 		}
 
 		ob_start();
-		$esc = callback('Nette\Templating\Helpers::escapeHtml');
+		$esc = class_exists('\Nette\Templating\Helpers')
+			? Callback::closure( 'Nette\Templating\Helpers::escapeHtml')
+			: Callback::closure( '\Latte\Runtime\Filters::escapeHtml');
 		$click = class_exists('\Tracy\Dumper')
 			? function ($o, $c = FALSE, $d = 4) {
 				return \Tracy\Dumper::toHtml($o, array('collapse' => $c, 'depth' => $d));
 			}
-			: callback('\Tracy\Helpers::clickableDump');
+			: Callback::closure('\Tracy\Helpers::clickableDump');
 		$totalTime = $this->totalTime ? sprintf('%0.3f', $this->totalTime * 1000) . ' ms' : 'none';
 		$extractData = function ($object) {
 			if ($object instanceof Elastica\Request) {


### PR DESCRIPTION
as I did not have nette/deprecated in main project, Kdyby/ElasticSearch suddenly broke on callback() calls in Panel
Second issue is with escapeHtml function that is now moved to Latte\Runtime\Filters if I traced it correctly.

Not sure if check for old class is necessary if declared require is 2.3
