### PR TITLE
Fix deprecated keywords in configuration example

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -33,13 +33,13 @@ elasticSearch:
 	path: NULL
 	proxy: NULL
 	transport: 'Http'
-	persistent: on
+	persistent: yes
 	timeout: 300
 	config:
 		curl: [] # curl options
 		headers: [] # additional curl headers
 		url: [] # completely custom URL endpoint
-	roundRobin: off
+	roundRobin: no
 	retryOnConflict: 0
 ```
 


### PR DESCRIPTION
Fix deprecated keywords `on` and `off` in configuration example.
Deprecated since Neon 3.1 - https://github.com/nette/neon/pull/41